### PR TITLE
fix: guard against crash in 't m' with missing/invalid priority

### DIFF
--- a/t/main.swift
+++ b/t/main.swift
@@ -74,7 +74,11 @@ do {
 	        case "d":
                 try remCache.deleteReminders(  hashes: words.map { $0.uppercased() })
 	        case "m":
-				let priority = EisenhowerConsoleView.priority_map[words[0]]!
+				guard let priorityArg = words.first,
+				      let priority = EisenhowerConsoleView.priority_map[priorityArg] else {
+					print("# Error: 'm' requires a valid priority and at least one hash, e.g. t m ui a28")
+					exit(EXIT_FAILURE)
+				}
                 try remCache.moveReminders(    hashes: words.dropFirst().map { $0.uppercased() }, priority: priority)
 	        case "uih", "ui", "uil", "nuih", "nui", "nuil", "unih", "uni", "unil", "nuni",
 	        	 "1",   "2",  "3",   "4",    "5",   "6",    "7",    "8",   "9",    "0":		// Can pass text or number


### PR DESCRIPTION
## Summary
- `t m` with no further arguments, or with an unrecognized priority argument, force-unwrapped an array index / dictionary lookup driven directly by user input and trapped the process instead of erroring gracefully.
- Replaces the force-unwrap with a `guard let` that prints a usage hint and exits cleanly (`EXIT_FAILURE`) on bad input.
- Addresses finding F1 from `docs/reviews/PROJECT_REVIEW.md`.

## Test plan
- [x] `xcodebuild -project t.xcodeproj -scheme t -configuration Debug build` succeeds
- [x] Manually confirmed in a regular terminal: `t m` (no args) and `t m <bad-priority> <hash>` now print an error and exit instead of crashing; `t m <priority> <hash>` still moves the reminder as before