### PR TITLE
fix: await Reminders access grant before fetching reminders

### DIFF
--- a/t/ReminderCache.swift
+++ b/t/ReminderCache.swift
@@ -27,13 +27,15 @@ class ReminderCache {
     
     init() async {
         self.eventStore = EKEventStore()
-        eventStore.requestAccess(to: EKEntityType.reminder, completion: {
-            (granted, error) in
-            if (!granted) || (error != nil) {
-                print("Reminder access denied!")
-                exit(EXIT_FAILURE)
+        let granted = await withCheckedContinuation { continuation in
+            eventStore.requestAccess(to: EKEntityType.reminder) { granted, error in
+                continuation.resume(returning: granted && error == nil)
             }
-        })
+        }
+        guard granted else {
+            print("Reminder access denied!")
+            exit(EXIT_FAILURE)
+        }
         for reminder in await fetchReminders() {
             self.reminders[reminder.key] = reminder
         }


### PR DESCRIPTION
## Summary
- `ReminderCache.init` called `eventStore.requestAccess(to:completion:)` without waiting for the callback, then immediately awaited `fetchReminders()`. On first launch (or whenever access hasn't been granted yet), the fetch could race ahead of the permission grant and silently return an empty cache instead of the real reminder list.
- Wraps `requestAccess` in the same `withCheckedContinuation` pattern already used for `fetchReminders(matching:)` in this file, and guards on the granted result before fetching.
- Addresses finding F2 from `docs/reviews/PROJECT_REVIEW.md`.

## Test plan
- [x] `xcodebuild -project t.xcodeproj -scheme t -configuration Debug build` succeeds
- [x] Manually confirmed in a regular terminal that reminder access/fetch still works correctly