### PR TITLE
refactor: centralize the priority-to-quadrant mapping in a Priority enum

### DIFF
--- a/t.xcodeproj/project.pbxproj
+++ b/t.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		C15973D9287F3306003F8C28 /* ReminderCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15973D6287F3306003F8C28 /* ReminderCache.swift */; };
 		C15973DA287F3306003F8C28 /* EisenhowerConsoleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15973D7287F3306003F8C28 /* EisenhowerConsoleView.swift */; };
 		C15973DB287F3306003F8C28 /* extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15973D8287F3306003F8C28 /* extensions.swift */; };
+		14B3C8BBA99A03CDC0A21FEA /* Priority.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3CFCD411F7DD0BCE2F12AC5 /* Priority.swift */; };
 		C15973E7287F3E67003F8C28 /* extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15973D8287F3306003F8C28 /* extensions.swift */; };
 		C15973E9287F3E9F003F8C28 /* reminderExtension_tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15973E8287F3E9F003F8C28 /* reminderExtension_tests.swift */; };
 /* End PBXBuildFile section */
@@ -33,6 +34,7 @@
 		C15973D6287F3306003F8C28 /* ReminderCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReminderCache.swift; sourceTree = "<group>"; };
 		C15973D7287F3306003F8C28 /* EisenhowerConsoleView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EisenhowerConsoleView.swift; sourceTree = "<group>"; };
 		C15973D8287F3306003F8C28 /* extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = extensions.swift; sourceTree = "<group>"; };
+		A3CFCD411F7DD0BCE2F12AC5 /* Priority.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Priority.swift; sourceTree = "<group>"; };
 		C15973E0287F3E5B003F8C28 /* t_tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = t_tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C15973E8287F3E9F003F8C28 /* reminderExtension_tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = reminderExtension_tests.swift; sourceTree = "<group>"; };
 		C1A5DBA72DEA355A006B5FAF /* t.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = t.entitlements; sourceTree = "<group>"; };
@@ -81,6 +83,7 @@
 				C15973D7287F3306003F8C28 /* EisenhowerConsoleView.swift */,
 				C15973D8287F3306003F8C28 /* extensions.swift */,
 				C15973CF287F30F8003F8C28 /* main.swift */,
+				A3CFCD411F7DD0BCE2F12AC5 /* Priority.swift */,
 				C15973D6287F3306003F8C28 /* ReminderCache.swift */,
 			);
 			path = t;
@@ -187,6 +190,7 @@
 				C15973D9287F3306003F8C28 /* ReminderCache.swift in Sources */,
 				C15973D0287F30F8003F8C28 /* main.swift in Sources */,
 				C15973DB287F3306003F8C28 /* extensions.swift in Sources */,
+				14B3C8BBA99A03CDC0A21FEA /* Priority.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/t/EisenhowerConsoleView.swift
+++ b/t/EisenhowerConsoleView.swift
@@ -28,41 +28,16 @@ public class EisenhowerConsoleView {
     }()
     var remCache: ReminderCache
 
-    // Map strings to the 10 priority levels in Reminders
     // Priority values specify which quadrant the item appears in
-    // and the sorting inside the quadrant.
+    // and the sorting inside the quadrant. See Priority.swift for
+    // the name/digit -> quadrant mapping.
     //     uih (1)   |    nuih (4)
     //     ui  (2)   |    nui  (5)
     //     uil (3)   |    nuil (6)
     //   -----------------------
-    //     uih (7)   |     
+    //     uih (7)   |
     //     ui  (8)   |    nuni (0)
-    //     uil (9)   |     
-
-    static let priority_map = [
-        "uih":  1,         // urgent,     important (high)
-        "ui":   2,         // urgent,     important (normal)
-        "uil":  3,         // urgent,     important (low)
-        "nuih": 4,         // not urgent, important (high)
-        "nui":  5,         // not urgent, important (normal)
-        "nuil": 6,         // not urgent, important (low)
-        "unih": 7,         // urgent,     not important (high)
-        "uni":  8,         // urgent,     not important (normal)
-        "unil": 9,         // urgent,     not important (low)
-        "nuni": 0,         // not urgent, not important
-    
-        "1":    1,         // urgent,     important (high)
-        "2":    2,         // urgent,     important (normal)
-        "3":    3,         // urgent,     important (low)
-        "4":    4,         // not urgent, important (high)
-        "5":    5,         // not urgent, important (normal)
-        "6":    6,         // not urgent, important (low)
-        "7":    7,         // urgent,     not important (high)
-        "8":    8,         // urgent,     not important (normal)
-        "9":    9,         // urgent,     not important (low)
-        "0":    0          // not urgent, not important
-    ]
-
+    //     uil (9)   |
 
 	init(reminders: ReminderCache) {
         var w = winsize()
@@ -82,7 +57,7 @@ public class EisenhowerConsoleView {
      Made up of 4 fields:
         1. check box if completed
         2. a 3 digit hex hash
-        3. a 0-9 digit for priority (see priority_map above)
+        3. a 0-9 digit for priority (see Priority.swift)
         4. the reminder text (aka title)
 
      e.g. " ✔  A43 8 Eat Breakfast           "

--- a/t/Priority.swift
+++ b/t/Priority.swift
@@ -1,0 +1,45 @@
+
+/// The 10 priority levels used by Reminders (mirrors `EKReminder.priority`,
+/// 0-9), repurposed here to select an Eisenhower quadrant and the sort
+/// order within it. This is the single source of truth for that mapping;
+/// previously it was hand-duplicated across `ReminderCache`,
+/// `EisenhowerConsoleView`, and `main.swift`.
+enum Priority: Int, CaseIterable {
+    case uih  = 1   // urgent,     important (high)
+    case ui   = 2   // urgent,     important (normal)
+    case uil  = 3   // urgent,     important (low)
+    case nuih = 4   // not urgent, important (high)
+    case nui  = 5   // not urgent, important (normal)
+    case nuil = 6   // not urgent, important (low)
+    case unih = 7   // urgent,     not important (high)
+    case uni  = 8   // urgent,     not important (normal)
+    case unil = 9   // urgent,     not important (low)
+    case nuni = 0   // not urgent, not important
+
+    enum Quadrant {
+        case urgentImportant        // top-left:     "DO"
+        case notUrgentImportant     // top-right:    "PLAN"
+        case urgentNotImportant     // bottom-left:  "DELEGATE"
+        case notUrgentNotImportant  // bottom-right: "ELIMINATE"
+    }
+
+    var quadrant: Quadrant {
+        switch self {
+        case .uih, .ui, .uil:    return .urgentImportant
+        case .nuih, .nui, .nuil: return .notUrgentImportant
+        case .unih, .uni, .unil: return .urgentNotImportant
+        case .nuni:               return .notUrgentNotImportant
+        }
+    }
+
+    /// Accepts either the case name ("ui", "nuih", ...) or the equivalent digit ("2", "4", ...).
+    init?(name: String) {
+        if let byName = Priority.allCases.first(where: { "\($0)" == name }) {
+            self = byName
+        } else if let byNumber = Int(name), let byRaw = Priority(rawValue: byNumber) {
+            self = byRaw
+        } else {
+            return nil
+        }
+    }
+}

--- a/t/ReminderCache.swift
+++ b/t/ReminderCache.swift
@@ -4,17 +4,17 @@ import EventKit
 typealias ReminderDict = [String: EKReminder]
 
 extension ReminderDict {
-    // Return a dict of Reminders with priorities in the specied range
-    func remindersWithPriorities(_ priorities: [Int]) -> ReminderDict {
+    // Return a dict of Reminders whose priority falls in the given quadrant
+    func reminders(in quadrant: Priority.Quadrant) -> ReminderDict {
         return self.filter { _, reminder in
-            return priorities.contains(reminder.priority)
+            return Priority(rawValue: reminder.priority)?.quadrant == quadrant
         }
     }
-    
-    var uiItems:   ReminderDict { get { remindersWithPriorities([1,2,3]) } }  // urgent and important items
-    var nuiItems:  ReminderDict { get { remindersWithPriorities([4,5,6]) } }  // not urgent but important items
-    var uniItems:  ReminderDict { get { remindersWithPriorities([7,8,9]) } }  // urgent but not important items
-    var nuniItems: ReminderDict { get { remindersWithPriorities(  [0]  ) } }  // not urgent and not important items
+
+    var uiItems:   ReminderDict { get { reminders(in: .urgentImportant) } }        // urgent and important items
+    var nuiItems:  ReminderDict { get { reminders(in: .notUrgentImportant) } }     // not urgent but important items
+    var uniItems:  ReminderDict { get { reminders(in: .urgentNotImportant) } }     // urgent but not important items
+    var nuniItems: ReminderDict { get { reminders(in: .notUrgentNotImportant) } }  // not urgent and not important items
 }
 
 class ReminderCache {

--- a/t/main.swift
+++ b/t/main.swift
@@ -75,18 +75,14 @@ do {
                 try remCache.deleteReminders(  hashes: words.map { $0.uppercased() })
 	        case "m":
 				guard let priorityArg = words.first,
-				      let priority = EisenhowerConsoleView.priority_map[priorityArg] else {
+				      let priority = Priority(name: priorityArg) else {
 					print("# Error: 'm' requires a valid priority and at least one hash, e.g. t m ui a28")
 					exit(EXIT_FAILURE)
 				}
-                try remCache.moveReminders(    hashes: words.dropFirst().map { $0.uppercased() }, priority: priority)
-	        case "uih", "ui", "uil", "nuih", "nui", "nuil", "unih", "uni", "unil", "nuni",
-	        	 "1",   "2",  "3",   "4",    "5",   "6",    "7",    "8",   "9",    "0":		// Can pass text or number
+                try remCache.moveReminders(    hashes: words.dropFirst().map { $0.uppercased() }, priority: priority.rawValue)
+	        default:		// Can pass a priority name or number, e.g. "ui" or "2"; anything else defaults to priority 0
                 let title = words.joined(separator: " ")
-	            try remCache.addReminder (title: title,  priority: EisenhowerConsoleView.priority_map[command]!)
-	        default:
-                let title = words.joined(separator: " ")
-	            try remCache.addReminder (title: title, priority: 0)
+	            try remCache.addReminder (title: title, priority: Priority(name: command)?.rawValue ?? 0)
         }
     }
     


### PR DESCRIPTION
## Summary
- The 0-9 priority → Eisenhower-quadrant mapping was hand-duplicated across three places: `ReminderCache`'s hardcoded `[1,2,3]`/`[4,5,6]`/... filter arrays, `EisenhowerConsoleView.priority_map` (a `[String:Int]`), and `main.swift`'s parallel list of name/digit case labels. Nothing enforced that the three stayed in sync.
- Adds `Priority: Int, CaseIterable` (`t/Priority.swift`) with a `quadrant` property and a `name`-based failable initializer (accepts both `"ui"`-style names and digit strings like `"2"`), and makes it the single source of truth:
  - `ReminderCache`'s `ReminderDict` quadrant accessors now filter by `Priority(rawValue:)?.quadrant` instead of literal `Int` arrays.
  - `EisenhowerConsoleView.priority_map` is removed.
  - `main.swift`'s 10-case literal match collapses into the `default` branch via `Priority(name:)`, removing the parallel name list.
- `ReminderCache`'s public API still speaks `EKReminder`'s native `Int` priority at the EventKit boundary; `Priority.rawValue` converts at the CLI/rendering edges where the previous duplication actually lived.
- Addresses finding F5 from `docs/reviews/PROJECT_REVIEW.md`.

## Test plan
- [x] `xcodebuild -project t.xcodeproj -scheme t -configuration Debug build` succeeds
- [ ] Manual verification in a regular terminal that add/move/list still resolve priorities to the correct quadrant (not yet confirmed by a human — this sandbox has no Reminders access to exercise it end-to-end)