### PR TITLE
test: add real ReminderCache coverage, wire test target into scheme

### DIFF
--- a/t.xcodeproj/project.pbxproj
+++ b/t.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		C15973DB287F3306003F8C28 /* extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15973D8287F3306003F8C28 /* extensions.swift */; };
 		C15973E7287F3E67003F8C28 /* extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15973D8287F3306003F8C28 /* extensions.swift */; };
 		C15973E9287F3E9F003F8C28 /* reminderExtension_tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15973E8287F3E9F003F8C28 /* reminderExtension_tests.swift */; };
+		F30000012F0000000000F301 /* ReminderCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15973D6287F3306003F8C28 /* ReminderCache.swift */; };
+		F30000022F0000000000F301 /* ReminderCache_tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30000032F0000000000F301 /* ReminderCache_tests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -35,6 +37,7 @@
 		C15973D8287F3306003F8C28 /* extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = extensions.swift; sourceTree = "<group>"; };
 		C15973E0287F3E5B003F8C28 /* t_tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = t_tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C15973E8287F3E9F003F8C28 /* reminderExtension_tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = reminderExtension_tests.swift; sourceTree = "<group>"; };
+		F30000032F0000000000F301 /* ReminderCache_tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderCache_tests.swift; sourceTree = "<group>"; };
 		C1A5DBA72DEA355A006B5FAF /* t.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = t.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -90,6 +93,7 @@
 			isa = PBXGroup;
 			children = (
 				C15973E8287F3E9F003F8C28 /* reminderExtension_tests.swift */,
+				F30000032F0000000000F301 /* ReminderCache_tests.swift */,
 			);
 			path = t_tests;
 			sourceTree = "<group>";
@@ -196,6 +200,8 @@
 			files = (
 				C15973E9287F3E9F003F8C28 /* reminderExtension_tests.swift in Sources */,
 				C15973E7287F3E67003F8C28 /* extensions.swift in Sources */,
+				F30000012F0000000000F301 /* ReminderCache.swift in Sources */,
+				F30000022F0000000000F301 /* ReminderCache_tests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/t.xcodeproj/xcshareddata/xcschemes/t.xcscheme
+++ b/t.xcodeproj/xcshareddata/xcschemes/t.xcscheme
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C15973DF287F3E5B003F8C28"
+               BuildableName = "t_tests.xctest"
+               BlueprintName = "t_tests"
+               ReferencedContainer = "container:t.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/t/ReminderCache.swift
+++ b/t/ReminderCache.swift
@@ -24,7 +24,16 @@ class ReminderCache {
     
     var eventStore: EKEventStore
     var reminders = ReminderDict()
-    
+
+    /**
+     Test-only initializer: bypasses the Reminders permission prompt and real EventKit fetch,
+     so tests can exercise cache logic without touching the user's actual Reminders data.
+     */
+    init(eventStore: EKEventStore, reminders: ReminderDict = ReminderDict()) {
+        self.eventStore = eventStore
+        self.reminders = reminders
+    }
+
     init() async {
         self.eventStore = EKEventStore()
         let granted = await withCheckedContinuation { continuation in

--- a/t_tests/ReminderCache_tests.swift
+++ b/t_tests/ReminderCache_tests.swift
@@ -6,30 +6,119 @@
 //
 
 import XCTest
+import EventKit
 
 final class ReminderCache_tests: XCTestCase {
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+    private func reminder(priority: Int) -> EKReminder {
+        let reminder = EKReminder(eventStore: EKEventStore())
+        reminder.priority = priority
+        return reminder
     }
 
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    // MARK: - remindersWithPriorities / quadrant accessors
+
+    func testRemindersWithPriorities_filtersToRequestedSet() throws {
+        let dict: ReminderDict = [
+            "aaa": reminder(priority: 1),
+            "bbb": reminder(priority: 4),
+            "ccc": reminder(priority: 7),
+            "ddd": reminder(priority: 0),
+        ]
+
+        let filtered = dict.remindersWithPriorities([1, 4])
+
+        XCTAssertEqual(Set(filtered.keys), Set(["aaa", "bbb"]))
     }
 
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    func testUiItems_returnsPriorities1To3() throws {
+        let dict: ReminderDict = [
+            "aaa": reminder(priority: 1),
+            "bbb": reminder(priority: 2),
+            "ccc": reminder(priority: 3),
+            "decoy": reminder(priority: 4),
+        ]
+
+        XCTAssertEqual(Set(dict.uiItems.keys), Set(["aaa", "bbb", "ccc"]))
     }
 
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
+    func testNuiItems_returnsPriorities4To6() throws {
+        let dict: ReminderDict = [
+            "aaa": reminder(priority: 4),
+            "bbb": reminder(priority: 5),
+            "ccc": reminder(priority: 6),
+            "decoy1": reminder(priority: 3),
+            "decoy2": reminder(priority: 7),
+        ]
+
+        XCTAssertEqual(Set(dict.nuiItems.keys), Set(["aaa", "bbb", "ccc"]))
+    }
+
+    func testUniItems_returnsPriorities7To9() throws {
+        let dict: ReminderDict = [
+            "aaa": reminder(priority: 7),
+            "bbb": reminder(priority: 8),
+            "ccc": reminder(priority: 9),
+            "decoy1": reminder(priority: 6),
+            "decoy2": reminder(priority: 0),
+        ]
+
+        XCTAssertEqual(Set(dict.uniItems.keys), Set(["aaa", "bbb", "ccc"]))
+    }
+
+    func testNuniItems_returnsPriority0Only() throws {
+        let dict: ReminderDict = [
+            "aaa": reminder(priority: 0),
+            "decoy1": reminder(priority: 1),
+            "decoy2": reminder(priority: 9),
+        ]
+
+        XCTAssertEqual(Set(dict.nuniItems.keys), Set(["aaa"]))
+    }
+
+    // MARK: - addReminder
+
+    func testAddReminder_emptyTitle_throwsEmptyTitleError() throws {
+        let cache = ReminderCache(eventStore: EKEventStore())
+
+        XCTAssertThrowsError(try cache.addReminder(title: "", priority: 1)) { error in
+            guard case ReminderCache.Error.EmptyTitleError = error else {
+                XCTFail("Expected EmptyTitleError, got \(error)")
+                return
+            }
         }
+    }
+
+    // MARK: - unknown-hash no-ops (moveReminders/deleteReminders/completeReminders)
+
+    func testMoveReminders_unknownHash_leavesCacheUnchanged() throws {
+        let known = reminder(priority: 1)
+        let cache = ReminderCache(eventStore: EKEventStore(), reminders: ["aaa": known])
+
+        try cache.moveReminders(hashes: ["zzz"], priority: 5)
+
+        XCTAssertEqual(cache.reminders.count, 1)
+        XCTAssertEqual(cache.reminders["aaa"]?.priority, 1)
+    }
+
+    func testDeleteReminders_unknownHash_leavesCacheUnchanged() throws {
+        let known = reminder(priority: 1)
+        let cache = ReminderCache(eventStore: EKEventStore(), reminders: ["aaa": known])
+
+        try cache.deleteReminders(hashes: ["zzz"])
+
+        XCTAssertEqual(cache.reminders.count, 1)
+        XCTAssertNotNil(cache.reminders["aaa"])
+    }
+
+    func testCompleteReminders_unknownHash_leavesCacheUnchanged() throws {
+        let known = reminder(priority: 1)
+        let cache = ReminderCache(eventStore: EKEventStore(), reminders: ["aaa": known])
+
+        try cache.completeReminders(hashes: ["zzz"])
+
+        XCTAssertEqual(cache.reminders.count, 1)
+        XCTAssertEqual(cache.reminders["aaa"]?.isCompleted, false)
     }
 
 }


### PR DESCRIPTION
## Summary
- Fixes F3 from `docs/reviews/PROJECT_REVIEW.md`: `ReminderCache_tests.swift` was the unedited Xcode template (empty `testExample`/`testPerformanceExample`), and `ReminderCache.swift`/the test file weren't wired into the `t_tests` target's Sources build phase at all, so nothing could compile against `ReminderCache`.
- Also fixes F4 in the same pass: the shared scheme's `TestAction` had an empty `<Testables>` list, so `xcodebuild test -scheme t` / Cmd-U silently ran zero tests. Added the `t_tests` target to the scheme's `TestAction`.
- Adds a synchronous DI initializer (`init(eventStore:reminders:)`) to `ReminderCache` so tests can exercise cache logic against in-memory `EKReminder` objects without requesting real Reminders access or touching the user's actual data — same safety pattern already used by the existing `reminderExtension_tests.swift`.
- New coverage: `remindersWithPriorities`/quadrant accessors (`uiItems`/`nuiItems`/`uniItems`/`nuniItems`), `addReminder`'s `EmptyTitleError` path, and the unknown-hash no-op behavior of `moveReminders`/`deleteReminders`/`completeReminders`.

## Test plan
- [x] `xcodebuild build-for-testing -project t.xcodeproj -scheme t -destination 'platform=macOS'` succeeds
- [x] `xcodebuild test -project t.xcodeproj -scheme t -destination 'platform=macOS' -only-testing:t_tests/ReminderCache_tests` — 9/9 tests pass