### PR TITLE
fix: recognize --help and -h as usage commands

### DIFF
--- a/Sources/t/main.swift
+++ b/Sources/t/main.swift
@@ -66,7 +66,7 @@ do {
     	let words = Array(args.dropFirst())
         let command = args.first?.lowercased() ?? "unknown"
         switch command {
-			case "h":
+			case "h", "-h", "--help":
 				usage()
 				exit(EXIT_SUCCESS)
 	        case "c":


### PR DESCRIPTION
## Summary
- `t --help` / `t -h` fell through to the `switch` default case in `main.swift`, silently creating a real reminder titled `--help`/`-h` at priority 0 instead of showing usage — likely the first command a new user types.
- Added `"-h", "--help"` alongside `"h"` in the command dispatch switch so both flags show usage and exit 0.

Fixes #11

## Test plan
- [x] `swift build` succeeds
- [x] `swift test` — all 12 tests pass
- [x] Manually verified `swift run t --help` and `swift run t -h` print usage and exit 0