### PR TITLE
fix: replace release-only-no-op assert with a real invariant check

### DIFF
--- a/Sources/t/ReminderCache.swift
+++ b/Sources/t/ReminderCache.swift
@@ -15,6 +15,26 @@ extension ReminderDict {
     var nuiItems:  ReminderDict { get { reminders(in: .notUrgentImportant) } }     // not urgent but important items
     var uniItems:  ReminderDict { get { reminders(in: .urgentNotImportant) } }     // urgent but not important items
     var nuniItems: ReminderDict { get { reminders(in: .notUrgentNotImportant) } }  // not urgent and not important items
+
+    /**
+     Splits the dict by the load invariant (every reminder should be either not completed,
+     or completed today). Reminders satisfying it come back as `valid`; any that don't
+     (e.g. completed on a previous day, which the load predicates shouldn't produce but
+     which external EventKit behavior could) come back as `invalid` instead of being
+     silently rendered or trapping the process.
+     */
+    func partitionedByLoadInvariant() -> (valid: ReminderDict, invalid: ReminderDict) {
+        var valid = ReminderDict()
+        var invalid = ReminderDict()
+        for (key, reminder) in self {
+            if !reminder.isCompleted || reminder.completedToday {
+                valid[key] = reminder
+            } else {
+                invalid[key] = reminder
+            }
+        }
+        return (valid, invalid)
+    }
 }
 
 class ReminderCache {

--- a/Sources/t/main.swift
+++ b/Sources/t/main.swift
@@ -56,9 +56,15 @@ func usage() {
 
 do {
     let remCache = await ReminderCache()    // load the reminders from the calendar
-    assert( remCache.reminders.values.filter { $0.isCompleted && !$0.completedToday }.count == 0,
-            "in \(#function), all reminders should be not completed or completed today!")
-    
+
+    // Every loaded reminder should be either not completed, or completed today (see the
+    // two-predicate fetch in ReminderCache.fetchReminders()). This is checked here rather
+    // than trusted, because unlike `assert`, this check also runs in release builds.
+    let (validReminders, invalidReminders) = remCache.reminders.partitionedByLoadInvariant()
+    if !invalidReminders.isEmpty {
+        print("# Warning: excluded \(invalidReminders.count) reminder(s) completed before today: \(invalidReminders.keys.sorted().joined(separator: ", "))")
+        remCache.reminders = validReminders
+    }
 
     var args = CommandLine.arguments
     args.remove(at:0)

--- a/Tests/t_tests/ReminderCache_tests.swift
+++ b/Tests/t_tests/ReminderCache_tests.swift
@@ -17,6 +17,13 @@ final class ReminderCache_tests: XCTestCase {
         return reminder
     }
 
+    private func reminder(isCompleted: Bool, completionDate: Date?) -> EKReminder {
+        let reminder = EKReminder(eventStore: EKEventStore())
+        reminder.isCompleted = isCompleted
+        reminder.completionDate = completionDate
+        return reminder
+    }
+
     // MARK: - reminders(in:) / quadrant accessors
 
     func testRemindersInQuadrant_filtersToRequestedQuadrant() throws {
@@ -75,6 +82,50 @@ final class ReminderCache_tests: XCTestCase {
         ]
 
         XCTAssertEqual(Set(dict.nuniItems.keys), Set(["aaa"]))
+    }
+
+    // MARK: - partitionedByLoadInvariant
+
+    func testPartitionedByLoadInvariant_incompleteReminder_isValid() throws {
+        let dict: ReminderDict = ["aaa": reminder(isCompleted: false, completionDate: nil)]
+
+        let (valid, invalid) = dict.partitionedByLoadInvariant()
+
+        XCTAssertEqual(Set(valid.keys), Set(["aaa"]))
+        XCTAssertTrue(invalid.isEmpty)
+    }
+
+    func testPartitionedByLoadInvariant_completedToday_isValid() throws {
+        let dict: ReminderDict = ["aaa": reminder(isCompleted: true, completionDate: Date())]
+
+        let (valid, invalid) = dict.partitionedByLoadInvariant()
+
+        XCTAssertEqual(Set(valid.keys), Set(["aaa"]))
+        XCTAssertTrue(invalid.isEmpty)
+    }
+
+    func testPartitionedByLoadInvariant_completedBeforeToday_isInvalid() throws {
+        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
+        let dict: ReminderDict = ["aaa": reminder(isCompleted: true, completionDate: yesterday)]
+
+        let (valid, invalid) = dict.partitionedByLoadInvariant()
+
+        XCTAssertTrue(valid.isEmpty)
+        XCTAssertEqual(Set(invalid.keys), Set(["aaa"]))
+    }
+
+    func testPartitionedByLoadInvariant_mixedReminders_splitsCorrectly() throws {
+        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
+        let dict: ReminderDict = [
+            "aaa": reminder(isCompleted: false, completionDate: nil),
+            "bbb": reminder(isCompleted: true, completionDate: Date()),
+            "ccc": reminder(isCompleted: true, completionDate: yesterday),
+        ]
+
+        let (valid, invalid) = dict.partitionedByLoadInvariant()
+
+        XCTAssertEqual(Set(valid.keys), Set(["aaa", "bbb"]))
+        XCTAssertEqual(Set(invalid.keys), Set(["ccc"]))
     }
 
     // MARK: - addReminder


### PR DESCRIPTION
## Summary
- `assert()` is compiled out entirely in `-O` release builds, so the one runtime check that every loaded reminder is either not completed or completed today was silently absent from exactly the binary `make release` produces (the one AGENTS.md documents as the working, entitled binary).
- Added `ReminderDict.partitionedByLoadInvariant()`, a pure/testable helper that splits loaded reminders into those satisfying the invariant and those that don't.
- `main.swift` now uses it after loading: any invariant-violating reminders are excluded from the cache and reported via a `#`-prefixed warning (matching the documented error-output convention), instead of trapping in Debug or silently doing nothing in Release.

Fixes #15

## Test plan
- [x] `swift build` succeeds
- [x] `swift build -c release` succeeds
- [x] `swift test` — all 16 tests pass (4 new tests covering `partitionedByLoadInvariant()`)