### PR TITLE
fix: detect and report hash key collisions during cache load

### DIFF
--- a/Sources/t/ReminderCache.swift
+++ b/Sources/t/ReminderCache.swift
@@ -35,6 +35,25 @@ extension ReminderDict {
         }
         return (valid, invalid)
     }
+    
+    /**
+     Build a ReminderDict keyed by `key(_:)` (defaults to `.key`), reporting any reminders whose
+     key collided with one already inserted (and were therefore dropped) instead of silently
+     overwriting them.
+     */
+    static func build(from reminders: [EKReminder], key: (EKReminder) -> String = { $0.key }) -> (dict: ReminderDict, collisions: [EKReminder]) {
+        var dict = ReminderDict()
+        var collisions: [EKReminder] = []
+        for reminder in reminders {
+            let k = key(reminder)
+            if dict[k] != nil {
+                collisions.append(reminder)
+            } else {
+                dict[k] = reminder
+            }
+        }
+        return (dict, collisions)
+    }
 }
 
 class ReminderCache {
@@ -65,8 +84,10 @@ class ReminderCache {
             print("Reminder access denied!")
             exit(EXIT_FAILURE)
         }
-        for reminder in await fetchReminders() {
-            self.reminders[reminder.key] = reminder
+        let (dict, collisions) = ReminderDict.build(from: await fetchReminders())
+        self.reminders = dict
+        if !collisions.isEmpty {
+            print("# WARNING: \(collisions.count) reminder(s) dropped due to a hash key collision")
         }
     }
     

--- a/Tests/t_tests/ReminderCache_tests.swift
+++ b/Tests/t_tests/ReminderCache_tests.swift
@@ -141,6 +141,30 @@ final class ReminderCache_tests: XCTestCase {
         }
     }
 
+    // MARK: - ReminderDict.build(from:) collision handling
+
+    func testBuild_noCollisions_keepsEveryReminder() throws {
+        let a = reminder(priority: 1)
+        let b = reminder(priority: 2)
+
+        let (dict, collisions) = ReminderDict.build(from: [a, b]) { $0 === a ? "aaa" : "bbb" }
+
+        XCTAssertEqual(Set(dict.keys), Set(["aaa", "bbb"]))
+        XCTAssertTrue(collisions.isEmpty)
+    }
+
+    func testBuild_collidingKey_dropsLaterReminderAndReportsIt() throws {
+        let first = reminder(priority: 1)
+        let second = reminder(priority: 2)
+
+        let (dict, collisions) = ReminderDict.build(from: [first, second]) { _ in "aaa" }
+
+        XCTAssertEqual(dict.count, 1)
+        XCTAssertTrue(dict["aaa"] === first)
+        XCTAssertEqual(collisions.count, 1)
+        XCTAssertTrue(collisions.first === second)
+    }
+
     // MARK: - unknown-hash no-ops (moveReminders/deleteReminders/completeReminders)
 
     func testMoveReminders_unknownHash_leavesCacheUnchanged() throws {


### PR DESCRIPTION
## Summary
- `AGENTS.md`'s "Key/hash caveat" undersold the actual behavior: `self.reminders[reminder.key] = reminder` in the load loop (`ReminderCache.swift:49`) silently overwrote the *first* of two reminders sharing a 3-char hash prefix — it wasn't merely ambiguous, it vanished from every quadrant for that run with zero indication anything was wrong.
- Added `ReminderDict.build(from:key:)`, a pure/testable helper that builds the keyed dict and separately collects any reminders that lost a collision instead of silently overwriting them. The `key` parameter defaults to `.key` but is injectable so tests can force deterministic collisions (EKReminder's `calendarItemIdentifier`, and therefore `.key`, is EventKit-assigned and can't be pinned to a fixed value from a test).
- `ReminderCache.init() async` now uses this helper and reports any dropped reminders via a `#`-prefixed warning, matching the documented error-output convention.
- This is the minimal "detect and log" fix the issue calls out — not the larger "widen the key" redesign, which remains a separate, bigger change if ever needed.

Fixes #14

## Test plan
- [x] `swift build` succeeds
- [x] `make build` succeeds (entitled binary)
- [x] `swift test` — all 14 tests pass (2 new: `testBuild_noCollisions_keepsEveryReminder`, `testBuild_collidingKey_dropsLaterReminderAndReportsIt`)