### PR TITLE
fix: surface reminders with out-of-range priority instead of silently dropping them

### DIFF
--- a/Sources/t/ReminderCache.swift
+++ b/Sources/t/ReminderCache.swift
@@ -54,6 +54,25 @@ extension ReminderDict {
         }
         return (dict, collisions)
     }
+
+    /**
+     Splits the dict by whether each reminder's `priority` maps to a known `Priority` case
+     (0-9). Reminders with a recognized priority come back as `recognized`; any with an
+     out-of-range priority (e.g. set by another app or import) come back as `unrecognized`
+     instead of silently matching no quadrant and never rendering.
+     */
+    func partitionedByRecognizedPriority() -> (recognized: ReminderDict, unrecognized: ReminderDict) {
+        var recognized = ReminderDict()
+        var unrecognized = ReminderDict()
+        for (key, reminder) in self {
+            if Priority(rawValue: reminder.priority) != nil {
+                recognized[key] = reminder
+            } else {
+                unrecognized[key] = reminder
+            }
+        }
+        return (recognized, unrecognized)
+    }
 }
 
 class ReminderCache {

--- a/Sources/t/main.swift
+++ b/Sources/t/main.swift
@@ -66,6 +66,14 @@ do {
         remCache.reminders = validReminders
     }
 
+    // Reminders with a priority outside 0-9 (e.g. set by another app/import) don't map to any
+    // quadrant and would otherwise render nowhere with no indication anything was hidden.
+    let (recognizedReminders, unrecognizedReminders) = remCache.reminders.partitionedByRecognizedPriority()
+    if !unrecognizedReminders.isEmpty {
+        print("# Warning: excluded \(unrecognizedReminders.count) reminder(s) with unrecognized priority not shown: \(unrecognizedReminders.keys.sorted().joined(separator: ", "))")
+        remCache.reminders = recognizedReminders
+    }
+
     var args = CommandLine.arguments
     args.remove(at:0)
     if args.count > 0 {

--- a/Tests/t_tests/ReminderCache_tests.swift
+++ b/Tests/t_tests/ReminderCache_tests.swift
@@ -128,6 +128,39 @@ final class ReminderCache_tests: XCTestCase {
         XCTAssertEqual(Set(invalid.keys), Set(["ccc"]))
     }
 
+    // MARK: - partitionedByRecognizedPriority
+
+    func testPartitionedByRecognizedPriority_priorityInRange_isRecognized() throws {
+        let dict: ReminderDict = ["aaa": reminder(priority: 5)]
+
+        let (recognized, unrecognized) = dict.partitionedByRecognizedPriority()
+
+        XCTAssertEqual(Set(recognized.keys), Set(["aaa"]))
+        XCTAssertTrue(unrecognized.isEmpty)
+    }
+
+    func testPartitionedByRecognizedPriority_priorityOutOfRange_isUnrecognized() throws {
+        let dict: ReminderDict = ["aaa": reminder(priority: 42)]
+
+        let (recognized, unrecognized) = dict.partitionedByRecognizedPriority()
+
+        XCTAssertTrue(recognized.isEmpty)
+        XCTAssertEqual(Set(unrecognized.keys), Set(["aaa"]))
+    }
+
+    func testPartitionedByRecognizedPriority_mixedReminders_splitsCorrectly() throws {
+        let dict: ReminderDict = [
+            "aaa": reminder(priority: 1),
+            "bbb": reminder(priority: 99),
+            "ccc": reminder(priority: -1),
+        ]
+
+        let (recognized, unrecognized) = dict.partitionedByRecognizedPriority()
+
+        XCTAssertEqual(Set(recognized.keys), Set(["aaa"]))
+        XCTAssertEqual(Set(unrecognized.keys), Set(["bbb", "ccc"]))
+    }
+
     // MARK: - addReminder
 
     func testAddReminder_emptyTitle_throwsEmptyTitleError() throws {


### PR DESCRIPTION
## Summary
- `ReminderDict.reminders(in:)` filters with `Priority(rawValue: reminder.priority)?.quadrant == quadrant`. If a reminder's `priority` falls outside 0-9 (e.g. set by another app or an import), `Priority(rawValue:)` returns `nil`, so the reminder matches *no* quadrant and never renders — even though it's still sitting in the cache with no indication anything was hidden.
- Added `ReminderDict.partitionedByRecognizedPriority()`, mirroring the `partitionedByLoadInvariant()` pattern introduced in #15/#27: splits reminders into `recognized` (maps to a known `Priority` case) and `unrecognized` (out-of-range priority).
- `main.swift` now excludes unrecognized-priority reminders from display and reports the count via a `#`-prefixed warning, consistent with the existing error-output convention, instead of silently dropping them.

Fixes #21

## Test plan
- [x] `swift build` succeeds
- [x] `make build` succeeds (entitled binary)
- [x] `swift test` — all 19 tests pass (3 new: `testPartitionedByRecognizedPriority_priorityInRange_isRecognized`, `testPartitionedByRecognizedPriority_priorityOutOfRange_isUnrecognized`, `testPartitionedByRecognizedPriority_mixedReminders_splitsCorrectly`)