### PR TITLE
fix: guard 't c'/'t d' against zero hash arguments

### DIFF
--- a/Sources/t/main.swift
+++ b/Sources/t/main.swift
@@ -84,8 +84,16 @@ do {
 				usage()
 				exit(EXIT_SUCCESS)
 	        case "c":
+				guard !words.isEmpty else {
+					print("# Error: 'c' requires at least one hash, e.g. t c a28")
+					exit(EXIT_FAILURE)
+				}
                 try remCache.completeReminders(hashes: words.map { $0.uppercased() })
 	        case "d":
+				guard !words.isEmpty else {
+					print("# Error: 'd' requires at least one hash, e.g. t d a28")
+					exit(EXIT_FAILURE)
+				}
                 try remCache.deleteReminders(  hashes: words.map { $0.uppercased() })
 	        case "m":
 				guard let priorityArg = words.first,


### PR DESCRIPTION
## Summary
- `t c` (complete) and `t d` (delete) with zero hash arguments fell through to `completeReminders`/`deleteReminders` with an empty array and silently did nothing — no feedback at all.
- `t m` already validates this exact case and prints a usage hint (`main.swift`), so `c`/`d` were inconsistent with the tool's own established pattern.
- Added the same "requires at least one hash" guard to the `c` and `d` cases, matching `m`'s existing style (`#`-prefixed error message + `exit(EXIT_FAILURE)`).

Fixes #23

## Test plan
- [x] `swift build` succeeds
- [x] `make build` succeeds (entitled binary)
- [x] `swift test` — all 21 tests pass (no regressions; the top-level command-dispatch switch isn't unit-testable without the #12 refactor)
- [x] Manually verified with the entitled binary: `t c` and `t d` with no arguments now print `# Error: 'c'/'d' requires at least one hash, e.g. t c a28` and exit non-zero, without touching any Reminders data (the guard runs before any EventKit call)