### PR TITLE
fix: batch EventKit commits in moveReminders/deleteReminders/completeReminders

### DIFF
--- a/Sources/t/ReminderCache.swift
+++ b/Sources/t/ReminderCache.swift
@@ -149,7 +149,7 @@ class ReminderCache {
         return incompleteReminders + completedTodayReminders
     }
     
-    func updateReminder(reminder: EKReminder, priority:Int? = nil, isCompleted: Bool? = nil) throws {
+    func updateReminder(reminder: EKReminder, priority:Int? = nil, isCompleted: Bool? = nil, commit: Bool = true) throws {
         self.reminders[reminder.key] = reminder
         if let priority {
             reminder.priority = priority
@@ -157,7 +157,7 @@ class ReminderCache {
         if let isCompleted {
             reminder.isCompleted = isCompleted
         }
-        try self.eventStore.save(reminder, commit:true);
+        try self.eventStore.save(reminder, commit: commit);
     }
     
     func addReminder(title: String, priority:Int) throws {
@@ -175,27 +175,42 @@ class ReminderCache {
     
     
     func moveReminders(hashes: [String], priority: Int) throws {
+        var didMutate = false
         for hash in hashes {
             if let reminder = reminders[hash] {
-                try self.updateReminder(reminder: reminder, priority: priority)
+                try self.updateReminder(reminder: reminder, priority: priority, commit: false)
+                didMutate = true
             }
         }
+        if didMutate {
+            try self.eventStore.commit()
+        }
     }
-    
+
     func deleteReminders(hashes:[String]) throws {
+        var didMutate = false
         for hash in hashes {
             if let reminder = reminders[hash] {
-                try self.eventStore.remove(reminder, commit:true)
+                try self.eventStore.remove(reminder, commit:false)
                 self.reminders[hash] = nil
+                didMutate = true
             }
         }
+        if didMutate {
+            try self.eventStore.commit()
+        }
     }
-    
+
     func completeReminders(hashes:[String]) throws {
+        var didMutate = false
         for hash in hashes {
             if let reminder = reminders[hash] {
-                try self.updateReminder(reminder: reminder, isCompleted: true)
+                try self.updateReminder(reminder: reminder, isCompleted: true, commit: false)
+                didMutate = true
             }
+        }
+        if didMutate {
+            try self.eventStore.commit()
         }
     }
     


### PR DESCRIPTION
## Summary
- `moveReminders`/`deleteReminders`/`completeReminders` each called `save`/`remove` with `commit: true` inside a `for hash in hashes` loop, so e.g. `t c a1 b2 c3` issued three separate synchronous EventKit commits instead of batching into one.
- `updateReminder` now takes a `commit: Bool = true` parameter. `addReminder`'s single-reminder call site is unaffected (default `true`, unchanged behavior).
- The three multi-hash mutators now pass `commit: false` inside their loops and call `eventStore.commit()` once at the end — only when at least one reminder was actually mutated, so the existing unknown-hash no-op behavior (and its tests) is preserved exactly.

Fixes #22

## Test plan
- [x] `swift build` succeeds
- [x] `make build` succeeds (entitled binary)
- [x] `swift test` — all 21 tests pass, no regressions, including the unknown-hash no-op tests (which confirm `eventStore.commit()` is never called when nothing was mutated)
- [x] No new automated coverage added for the actual batched-commit path itself — `ReminderCache_tests.swift` deliberately avoids exercising `save`/`remove` against real Reminders data (see #13, the tracked EventStoring-seam gap); verified by inspection instead