### PR TITLE
fix: prefix remaining error output with "#" to match documented convention

### DIFF
--- a/Sources/t/ReminderCache.swift
+++ b/Sources/t/ReminderCache.swift
@@ -100,7 +100,7 @@ class ReminderCache {
             }
         }
         guard granted else {
-            print("Reminder access denied!")
+            print("# Reminder access denied!")
             exit(EXIT_FAILURE)
         }
         let (dict, collisions) = ReminderDict.build(from: await fetchReminders())

--- a/Sources/t/main.swift
+++ b/Sources/t/main.swift
@@ -106,5 +106,5 @@ do {
 } catch ReminderCache.Error.EmptyTitleError {
     print("# Error: can't add reminder with empty title.")
 } catch {
-    print("Something is wrong, \(error)")
+    print("# Something is wrong, \(error)")
 }


### PR DESCRIPTION
## Summary
- `AGENTS.md` states "errors surface as `#`-prefixed comment lines," but the generic catch-all in `main.swift` (`print("Something is wrong, \(error)")`) and the access-denied message in `ReminderCache` (`print("Reminder access denied!")`) both omitted the prefix, while every other error message in the tool included it.
- Prefixed both with `#` so the documented convention is actually true everywhere.

Fixes #10

## Test plan
- [x] `swift build` succeeds
- [x] `make build` succeeds (entitled binary)
- [x] `swift test` — all 21 tests pass, no regressions