### PR TITLE
fix: remove unused NSDate ==/< operators

### DIFF
--- a/Sources/t/extensions.swift
+++ b/Sources/t/extensions.swift
@@ -1,14 +1,6 @@
 
 import EventKit
 
-public func ==(lhs: NSDate, rhs: NSDate) -> Bool {
-    return lhs === rhs || lhs.compare(rhs as Date) == .orderedSame
-}
-
-public func <(lhs: NSDate, rhs: NSDate) -> Bool {
-    return lhs.compare(rhs as Date) == .orderedAscending
-}
-
 extension EKReminder {
     
     /**


### PR DESCRIPTION
## Summary
- Custom `==`/`<` operators on `NSDate` in `extensions.swift` were defined but never called anywhere in `Sources/` or `Tests/` (confirmed via grep across both trees).
- Removed them per the issue's recommendation, rather than adding coverage for code nothing exercises.

Fixes #19

## Test plan
- [x] `swift build` succeeds
- [x] `make build` succeeds (entitled binary)
- [x] `swift test` — all 21 tests pass, no regressions