### PR TITLE
fix: match Priority.init?(name:) case names with an explicit switch

### DIFF
--- a/Sources/t/Priority.swift
+++ b/Sources/t/Priority.swift
@@ -34,12 +34,23 @@ enum Priority: Int, CaseIterable {
 
     /// Accepts either the case name ("ui", "nuih", ...) or the equivalent digit ("2", "4", ...).
     init?(name: String) {
-        if let byName = Priority.allCases.first(where: { "\($0)" == name }) {
-            self = byName
-        } else if let byNumber = Int(name), let byRaw = Priority(rawValue: byNumber) {
-            self = byRaw
-        } else {
-            return nil
+        switch name {
+        case "uih":  self = .uih
+        case "ui":   self = .ui
+        case "uil":  self = .uil
+        case "nuih": self = .nuih
+        case "nui":  self = .nui
+        case "nuil": self = .nuil
+        case "unih": self = .unih
+        case "uni":  self = .uni
+        case "unil": self = .unil
+        case "nuni": self = .nuni
+        default:
+            if let byNumber = Int(name), let byRaw = Priority(rawValue: byNumber) {
+                self = byRaw
+            } else {
+                return nil
+            }
         }
     }
 }

--- a/Tests/t_tests/Priority_tests.swift
+++ b/Tests/t_tests/Priority_tests.swift
@@ -1,0 +1,42 @@
+//
+//  Priority_tests.swift
+//  t_tests
+//
+
+import XCTest
+@testable import t
+
+final class Priority_tests: XCTestCase {
+
+    // MARK: - init?(name:) by case name
+
+    func testInitName_everyCaseName_roundTrips() throws {
+        for priority in Priority.allCases {
+            let name = "\(priority)"
+            XCTAssertEqual(Priority(name: name), priority, "name \"\(name)\" should resolve to \(priority)")
+        }
+    }
+
+    // MARK: - init?(name:) by digit
+
+    func testInitName_everyDigit_roundTrips() throws {
+        for priority in Priority.allCases {
+            let digit = "\(priority.rawValue)"
+            XCTAssertEqual(Priority(name: digit), priority, "digit \"\(digit)\" should resolve to \(priority)")
+        }
+    }
+
+    // MARK: - init?(name:) invalid input
+
+    func testInitName_unknownName_returnsNil() throws {
+        XCTAssertNil(Priority(name: "bogus"))
+    }
+
+    func testInitName_outOfRangeDigit_returnsNil() throws {
+        XCTAssertNil(Priority(name: "42"))
+    }
+
+    func testInitName_emptyString_returnsNil() throws {
+        XCTAssertNil(Priority(name: ""))
+    }
+}


### PR DESCRIPTION
## Summary
- `Priority.init?(name:)` matched case names via `"\($0)" == name` — string-interpolating the enum case rather than using an explicit table. Correctness silently depended on the default `CaseIterable` description staying exactly equal to each case's identifier, and would silently break if `Priority` ever adopted `CustomStringConvertible`.
- Replaced with an explicit `switch` listing each case name directly, per the issue's recommendation. The digit-matching fallback (`Int(name)` + `Priority(rawValue:)`) is unchanged.
- Added `Tests/t_tests/Priority_tests.swift` — this pure, dependency-free enum had no test coverage at all before now. Covers name round-trips for every case, digit round-trips for every case, and invalid input (unknown name, out-of-range digit, empty string).

Fixes #16

## Test plan
- [x] `swift build` succeeds
- [x] `make build` succeeds (entitled binary)
- [x] `swift test` — all 26 tests pass (5 new)