### PR TITLE
fix: drop lazy from leftMaxWidth/rightMaxWidth, compute in init

### DIFF
--- a/Sources/t/EisenhowerConsoleView.swift
+++ b/Sources/t/EisenhowerConsoleView.swift
@@ -7,31 +7,8 @@ public class EisenhowerConsoleView {
 	var leftcols:  Int      // final width of the left column (considering lengths of all left items)
 	var rightcols: Int      // final width of the right column
     
-    // Note: these ...MaxWidth properties probably don't benefit from the lazy
-    // keyword.  They are each executed exactly once for each execution,
-    // and they aren't particularly slow.  User wouldn't notice.
-    lazy var leftMaxWidth: Int = {
-        let longestLeftTitle = remCache.reminders.values
-            .filter { reminder in
-                let quadrant = Priority(rawValue: reminder.priority)?.quadrant
-                return quadrant == .urgentImportant || quadrant == .urgentNotImportant
-            }
-            .map { $0.title.count }
-            .max() ?? 0
-        let result = longestLeftTitle + 13
-        return result
-    }()
-    lazy var rightMaxWidth: Int = {
-        let longestRightTitle = remCache.reminders.values
-            .filter { reminder in
-                let quadrant = Priority(rawValue: reminder.priority)?.quadrant
-                return quadrant == .notUrgentImportant || quadrant == .notUrgentNotImportant
-            }
-            .map { $0.title.count }
-            .max() ?? 0
-        let result = longestRightTitle + 13
-        return result
-    }()
+    let leftMaxWidth: Int
+    let rightMaxWidth: Int
     var remCache: ReminderCache
 
     // Priority values specify which quadrant the item appears in
@@ -55,6 +32,24 @@ public class EisenhowerConsoleView {
         self.leftcols = Int(Double(self.cols) * 0.5)
 		self.rightcols = Int(self.cols) - self.leftcols
         self.remCache = reminders
+
+        let longestLeftTitle = remCache.reminders.values
+            .filter { reminder in
+                let quadrant = Priority(rawValue: reminder.priority)?.quadrant
+                return quadrant == .urgentImportant || quadrant == .urgentNotImportant
+            }
+            .map { $0.title.count }
+            .max() ?? 0
+        self.leftMaxWidth = longestLeftTitle + 13
+
+        let longestRightTitle = remCache.reminders.values
+            .filter { reminder in
+                let quadrant = Priority(rawValue: reminder.priority)?.quadrant
+                return quadrant == .notUrgentImportant || quadrant == .notUrgentNotImportant
+            }
+            .map { $0.title.count }
+            .max() ?? 0
+        self.rightMaxWidth = longestRightTitle + 13
 	}
 
     /**


### PR DESCRIPTION
## Summary
- `leftMaxWidth`/`rightMaxWidth` were `lazy var ... = { ... }()` closures. The adjacent comment already noted they "probably don't benefit from the lazy keyword" since each runs exactly once per execution — the code flagged its own uncertainty about the pattern.
- Computed both in `init` (after `remCache` is assigned, since they depend on it) and store them as immutable `let` properties instead, per the issue's recommendation.

Fixes #18

## Test plan
- [x] `swift build` succeeds
- [x] `make build` succeeds (entitled binary)
- [x] `swift test` — all 26 tests pass, no regressions
- [x] Manually ran the entitled binary (read-only, no mutation) and confirmed the matrix still renders correctly with the expected column widths — `EisenhowerConsoleView.swift` has no automated coverage yet (tracked separately in #17)