### PR TITLE
fix: extract command dispatch into a testable runCommand() function

### DIFF
--- a/Sources/t/main.swift
+++ b/Sources/t/main.swift
@@ -54,6 +54,57 @@ func usage() {
 	print("# $> t m uni a28    # moves the reminder with hash a28 to priority uni")
 }
 
+/// What `runCommand(args:cache:)` decided the top-level driver should do next. Distinct from a
+/// thrown `RunError` since showing usage is a successful outcome, not a failure.
+enum RunAction: Equatable {
+    case showUsage
+    case render
+}
+
+/// Argument-validation failures from `runCommand(args:cache:)`. Thrown rather than
+/// printed-and-exited directly so the dispatch logic stays callable (and testable) without
+/// terminating the process.
+enum RunError: Error, Equatable {
+    case invalidArguments(String)
+}
+
+/// Parses `args` (program name already stripped) and dispatches to the matching `cache` mutator.
+/// This is the command-dispatch switch that used to live inline in this file's top-level code,
+/// where it couldn't be unit tested at all.
+func runCommand(args: [String], cache: ReminderCache) throws -> RunAction {
+    guard !args.isEmpty else {
+        return .render
+    }
+
+    let words = Array(args.dropFirst())
+    let command = args.first?.lowercased() ?? "unknown"
+
+    switch command {
+    case "h", "-h", "--help":
+        return .showUsage
+    case "c":
+        guard !words.isEmpty else {
+            throw RunError.invalidArguments("'c' requires at least one hash, e.g. t c a28")
+        }
+        try cache.completeReminders(hashes: words.map { $0.uppercased() })
+    case "d":
+        guard !words.isEmpty else {
+            throw RunError.invalidArguments("'d' requires at least one hash, e.g. t d a28")
+        }
+        try cache.deleteReminders(hashes: words.map { $0.uppercased() })
+    case "m":
+        guard let priorityArg = words.first,
+              let priority = Priority(name: priorityArg) else {
+            throw RunError.invalidArguments("'m' requires a valid priority and at least one hash, e.g. t m ui a28")
+        }
+        try cache.moveReminders(hashes: words.dropFirst().map { $0.uppercased() }, priority: priority.rawValue)
+    default:   // Can pass a priority name or number, e.g. "ui" or "2"; anything else defaults to priority 0
+        let title = words.joined(separator: " ")
+        try cache.addReminder(title: title, priority: Priority(name: command)?.rawValue ?? 0)
+    }
+    return .render
+}
+
 do {
     let remCache = await ReminderCache()    // load the reminders from the calendar
 
@@ -74,45 +125,22 @@ do {
         remCache.reminders = recognizedReminders
     }
 
-    var args = CommandLine.arguments
-    args.remove(at:0)
-    if args.count > 0 {
-    	let words = Array(args.dropFirst())
-        let command = args.first?.lowercased() ?? "unknown"
-        switch command {
-			case "h", "-h", "--help":
-				usage()
-				exit(EXIT_SUCCESS)
-	        case "c":
-				guard !words.isEmpty else {
-					print("# Error: 'c' requires at least one hash, e.g. t c a28")
-					exit(EXIT_FAILURE)
-				}
-                try remCache.completeReminders(hashes: words.map { $0.uppercased() })
-	        case "d":
-				guard !words.isEmpty else {
-					print("# Error: 'd' requires at least one hash, e.g. t d a28")
-					exit(EXIT_FAILURE)
-				}
-                try remCache.deleteReminders(  hashes: words.map { $0.uppercased() })
-	        case "m":
-				guard let priorityArg = words.first,
-				      let priority = Priority(name: priorityArg) else {
-					print("# Error: 'm' requires a valid priority and at least one hash, e.g. t m ui a28")
-					exit(EXIT_FAILURE)
-				}
-                try remCache.moveReminders(    hashes: words.dropFirst().map { $0.uppercased() }, priority: priority.rawValue)
-	        default:		// Can pass a priority name or number, e.g. "ui" or "2"; anything else defaults to priority 0
-                let title = words.joined(separator: " ")
-	            try remCache.addReminder (title: title, priority: Priority(name: command)?.rawValue ?? 0)
-        }
+    let action = try runCommand(args: Array(CommandLine.arguments.dropFirst()), cache: remCache)
+
+    switch action {
+    case .showUsage:
+        usage()
+        exit(EXIT_SUCCESS)
+    case .render:
+        let view = EisenhowerConsoleView(reminders: remCache)
+        view.display()
     }
-    
-	let view = EisenhowerConsoleView(reminders: remCache)
-	view.display()
 
 } catch ReminderCache.Error.EmptyTitleError {
     print("# Error: can't add reminder with empty title.")
+} catch RunError.invalidArguments(let message) {
+    print("# Error: \(message)")
+    exit(EXIT_FAILURE)
 } catch {
     print("# Something is wrong, \(error)")
 }

--- a/Tests/t_tests/main_tests.swift
+++ b/Tests/t_tests/main_tests.swift
@@ -1,0 +1,126 @@
+//
+//  main_tests.swift
+//  t_tests
+//
+
+import XCTest
+import EventKit
+@testable import t
+
+final class main_tests: XCTestCase {
+
+    private func reminder(priority: Int) -> EKReminder {
+        let reminder = EKReminder(eventStore: EKEventStore())
+        reminder.priority = priority
+        return reminder
+    }
+
+    // MARK: - no command
+
+    func testRun_emptyArgs_returnsRender() throws {
+        let cache = ReminderCache(eventStore: EKEventStore())
+
+        XCTAssertEqual(try runCommand(args: [], cache: cache), .render)
+    }
+
+    // MARK: - h / -h / --help
+
+    func testRun_helpCommands_returnShowUsage() throws {
+        let cache = ReminderCache(eventStore: EKEventStore())
+
+        for helpArg in ["h", "-h", "--help"] {
+            XCTAssertEqual(try runCommand(args: [helpArg], cache: cache), .showUsage)
+        }
+    }
+
+    // MARK: - c / d argument validation (see #23)
+
+    func testRun_completeCommand_noHashes_throwsInvalidArguments() throws {
+        let cache = ReminderCache(eventStore: EKEventStore())
+
+        XCTAssertThrowsError(try runCommand(args: ["c"], cache: cache)) { error in
+            guard case RunError.invalidArguments(let message) = error else {
+                XCTFail("Expected RunError.invalidArguments, got \(error)")
+                return
+            }
+            XCTAssertTrue(message.contains("'c' requires at least one hash"))
+        }
+    }
+
+    func testRun_deleteCommand_noHashes_throwsInvalidArguments() throws {
+        let cache = ReminderCache(eventStore: EKEventStore())
+
+        XCTAssertThrowsError(try runCommand(args: ["d"], cache: cache)) { error in
+            guard case RunError.invalidArguments(let message) = error else {
+                XCTFail("Expected RunError.invalidArguments, got \(error)")
+                return
+            }
+            XCTAssertTrue(message.contains("'d' requires at least one hash"))
+        }
+    }
+
+    func testRun_completeCommand_unknownHash_returnsRenderAndLeavesCacheUnchanged() throws {
+        let known = reminder(priority: 1)
+        let cache = ReminderCache(eventStore: EKEventStore(), reminders: ["aaa": known])
+
+        let action = try runCommand(args: ["c", "zzz"], cache: cache)
+
+        XCTAssertEqual(action, .render)
+        XCTAssertEqual(cache.reminders.count, 1)
+        XCTAssertEqual(cache.reminders["aaa"]?.isCompleted, false)
+    }
+
+    func testRun_deleteCommand_unknownHash_returnsRenderAndLeavesCacheUnchanged() throws {
+        let known = reminder(priority: 1)
+        let cache = ReminderCache(eventStore: EKEventStore(), reminders: ["aaa": known])
+
+        let action = try runCommand(args: ["d", "zzz"], cache: cache)
+
+        XCTAssertEqual(action, .render)
+        XCTAssertEqual(cache.reminders.count, 1)
+        XCTAssertNotNil(cache.reminders["aaa"])
+    }
+
+    // MARK: - m argument validation
+
+    func testRun_moveCommand_missingPriority_throwsInvalidArguments() throws {
+        let cache = ReminderCache(eventStore: EKEventStore())
+
+        XCTAssertThrowsError(try runCommand(args: ["m"], cache: cache)) { error in
+            guard case RunError.invalidArguments(let message) = error else {
+                XCTFail("Expected RunError.invalidArguments, got \(error)")
+                return
+            }
+            XCTAssertTrue(message.contains("'m' requires a valid priority"))
+        }
+    }
+
+    func testRun_moveCommand_invalidPriorityName_throwsInvalidArguments() throws {
+        let cache = ReminderCache(eventStore: EKEventStore())
+
+        XCTAssertThrowsError(try runCommand(args: ["m", "bogus"], cache: cache))
+    }
+
+    func testRun_moveCommand_unknownHash_returnsRenderAndLeavesCacheUnchanged() throws {
+        let known = reminder(priority: 1)
+        let cache = ReminderCache(eventStore: EKEventStore(), reminders: ["aaa": known])
+
+        let action = try runCommand(args: ["m", "ui", "zzz"], cache: cache)
+
+        XCTAssertEqual(action, .render)
+        XCTAssertEqual(cache.reminders["aaa"]?.priority, 1)
+    }
+
+    // MARK: - default command (add reminder)
+
+    func testRun_defaultCommand_emptyTitle_throwsEmptyTitleError() throws {
+        let cache = ReminderCache(eventStore: EKEventStore())
+
+        XCTAssertThrowsError(try runCommand(args: ["ui"], cache: cache)) { error in
+            guard case ReminderCache.Error.EmptyTitleError = error else {
+                XCTFail("Expected EmptyTitleError, got \(error)")
+                return
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- The command-dispatch `switch` was inline top-level code in `main.swift`, which can't be unit tested at all — part of why the `t --help` footgun (#11) wasn't caught by tests, and why this file had 0% coverage.
- Extracted `runCommand(args:cache:) -> RunAction`, matching the issue's recommended `func run(args:cache:)` shape (renamed to `runCommand` — `run` collides with `XCTestCase`'s own instance method of the same name, which Swift's lookup silently prefers over the module-level free function inside a test class).
- The `guard`-`else` + `exit(EXIT_FAILURE)` validation blocks for `c`/`d`/`m` now `throw RunError.invalidArguments(String)` instead of calling `exit()` directly — `exit()` would kill the test process if it ran during a unit test. The top-level `catch` block maps that back to the identical `print` + `exit(EXIT_FAILURE)` behavior.
- Showing usage is now signaled via `RunAction.showUsage` rather than calling `exit()` inline, since it's a success outcome distinct from a thrown error.
- Behavior is unchanged — verified manually against the entitled binary for every dispatch path.

Fixes #12

## Test plan
- [x] `swift build` succeeds
- [x] `make build` succeeds (entitled binary)
- [x] `swift test` — all 36 tests pass (10 new, in `Tests/t_tests/main_tests.swift`), covering every branch of `runCommand()` that doesn't require touching real Reminders data: empty args, all three help variants, `c`/`d`/`m` validation errors, `c`/`d`/`m` with an unknown hash (safely no-ops, same pattern as existing `ReminderCache_tests`), and the default add-reminder path via an empty-title throw
- [x] Manually ran the entitled binary and confirmed byte-identical behavior for: `t --help`/`-h`/`h` (usage + exit 0), `t c`/`t d`/`t m` with no args (error + exit 1), `t m bogus` (error + exit 1), and `t` with no args (renders the matrix)