### PR TITLE
test: add coverage for EisenhowerConsoleView.swift and main.swift

### DIFF
--- a/Sources/t/main.swift
+++ b/Sources/t/main.swift
@@ -1,57 +1,59 @@
 import EventKit
 
-func usage() {
-	print("# usage: t [<command> <options>]")
-	print("#")
-	print("# List or modify reminders on the default calendar")
-	print("# Reminders are displayed in a four quadrant Eisenhower (urgent/important) matrix")
-	print("# see: https://en.wikipedia.org/wiki/Time_management#The_Eisenhower_Method")
-	print("#")
-	print("# Run the tool with no arguments to list the current reminders.")
-	print("# Each reminder shows up with a 3 hex-digit hash that is used to reference it.")
-	print("# For example:")
-	print("# ╭───────────────────────────┬─────────────────────────────────────╮")
-	print("# │    9D2 1 ride bike        │                                     │")
-	print("# │    CA8 2 Plan dinner date │                                     │")
-	print("# ├───────────────────────────┼─────────────────────────────────────┤")
-	print("# │                           │    C08 0 Download new IDA Pro       │")
-	print("# │                           │    AA0 0 Change Netflix password    │")
-	print("# │                           │    C8A 0 Reschedule eye exam        │")
-	print("# │                           │    E48 0 Fix outdoor light timers   │")
-	print("# │                           │ ✔  D33 0 cancel slack pro account   │")
-	print("# ╰───────────────────────────┴─────────────────────────────────────╯")
-	print("#")
-	print("# Examples:  ($ is the shell prompt)")
-	print("#   $ t ui Change Netflix password     # adds an urgent, important reminder to change your password")
-	print("#")
-	print("# The 'ui' string is a priority for the reminder, which determines which quadrant it appears in,")
-	print("# and the sorting in the quadrant, like this:")
-	print("#      uih (1)   |    nuih (4) ")
-	print("#      ui  (2)   |    nui  (5) ")
-	print("#      uil (3)   |    nuil (6) ")
-	print("#      ----------------------- ")
- 	print("#      uih (7)   |             ")
- 	print("#      ui  (8)   |    nuni (0) ")
-	print("#      uil (9)   |             ") 
-	print("#")
-	print("# Available priorities are: ")
-	print("#    uih   - priority 1: urgent & important (high)       [DO these tasks!]")
-	print("#    ui    - priority 2: urgent & important (normal)     [DO these tasks]")
-	print("#    uil   - priority 3: urgent & important (low)        [DO these tasks]")
-	print("#    nuih  - priority 4: not urgent & important (high)   [PLAN these tasks]")
-	print("#    nui   - priority 5: not urgent & important (normal) [PLAN these tasks]")
-	print("#    nuil  - priority 6: not urgent & important (low)    [PLAN these tasks]")
-	print("#    unih  - priority 7: urgent & not important (high)   [DELEGATE these tasks]")
-	print("#    uni   - priority 8: urgent & not important (normal) [DELEGATE these tasks]")
-	print("#    unil  - priority 9: urgent &  not important (low)   [DELEGATE these tasks]")
-	print("#    nuni  - priority 0: not urgent & not important.     [ELIMINATE these tasks]")
-	print("#")
-	print("#   Note:  you can also use the number priorities on the command line, e.g.")
-	print("#   $ t 1 Change Netflix password     # adds an urgent, important reminder to change your password")
-	print("#")
-	print("# $> t c 9d2        # marks the reminder with hash 9d2 as completed")
-	print("# $> t d 9d2        # deletes the reminder with hash 9d2")
-	print("# $> t m uni a28    # moves the reminder with hash a28 to priority uni")
+func usage() -> String {
+    return [
+        "# usage: t [<command> <options>]",
+        "#",
+        "# List or modify reminders on the default calendar",
+        "# Reminders are displayed in a four quadrant Eisenhower (urgent/important) matrix",
+        "# see: https://en.wikipedia.org/wiki/Time_management#The_Eisenhower_Method",
+        "#",
+        "# Run the tool with no arguments to list the current reminders.",
+        "# Each reminder shows up with a 3 hex-digit hash that is used to reference it.",
+        "# For example:",
+        "# ╭───────────────────────────┬─────────────────────────────────────╮",
+        "# │    9D2 1 ride bike        │                                     │",
+        "# │    CA8 2 Plan dinner date │                                     │",
+        "# ├───────────────────────────┼─────────────────────────────────────┤",
+        "# │                           │    C08 0 Download new IDA Pro       │",
+        "# │                           │    AA0 0 Change Netflix password    │",
+        "# │                           │    C8A 0 Reschedule eye exam        │",
+        "# │                           │    E48 0 Fix outdoor light timers   │",
+        "# │                           │ ✔  D33 0 cancel slack pro account   │",
+        "# ╰───────────────────────────┴─────────────────────────────────────╯",
+        "#",
+        "# Examples:  ($ is the shell prompt)",
+        "#   $ t ui Change Netflix password     # adds an urgent, important reminder to change your password",
+        "#",
+        "# The 'ui' string is a priority for the reminder, which determines which quadrant it appears in,",
+        "# and the sorting in the quadrant, like this:",
+        "#      uih (1)   |    nuih (4) ",
+        "#      ui  (2)   |    nui  (5) ",
+        "#      uil (3)   |    nuil (6) ",
+        "#      ----------------------- ",
+        "#      uih (7)   |             ",
+        "#      ui  (8)   |    nuni (0) ",
+        "#      uil (9)   |             ",
+        "#",
+        "# Available priorities are: ",
+        "#    uih   - priority 1: urgent & important (high)       [DO these tasks!]",
+        "#    ui    - priority 2: urgent & important (normal)     [DO these tasks]",
+        "#    uil   - priority 3: urgent & important (low)        [DO these tasks]",
+        "#    nuih  - priority 4: not urgent & important (high)   [PLAN these tasks]",
+        "#    nui   - priority 5: not urgent & important (normal) [PLAN these tasks]",
+        "#    nuil  - priority 6: not urgent & important (low)    [PLAN these tasks]",
+        "#    unih  - priority 7: urgent & not important (high)   [DELEGATE these tasks]",
+        "#    uni   - priority 8: urgent & not important (normal) [DELEGATE these tasks]",
+        "#    unil  - priority 9: urgent &  not important (low)   [DELEGATE these tasks]",
+        "#    nuni  - priority 0: not urgent & not important.     [ELIMINATE these tasks]",
+        "#",
+        "#   Note:  you can also use the number priorities on the command line, e.g.",
+        "#   $ t 1 Change Netflix password     # adds an urgent, important reminder to change your password",
+        "#",
+        "# $> t c 9d2        # marks the reminder with hash 9d2 as completed",
+        "# $> t d 9d2        # deletes the reminder with hash 9d2",
+        "# $> t m uni a28    # moves the reminder with hash a28 to priority uni",
+    ].joined(separator: "\n")
 }
 
 /// What `runCommand(args:cache:)` decided the top-level driver should do next. Distinct from a
@@ -129,7 +131,7 @@ do {
 
     switch action {
     case .showUsage:
-        usage()
+        print(usage())
         exit(EXIT_SUCCESS)
     case .render:
         let view = EisenhowerConsoleView(reminders: remCache)

--- a/Tests/t_tests/EisenhowerConsoleView_tests.swift
+++ b/Tests/t_tests/EisenhowerConsoleView_tests.swift
@@ -1,0 +1,116 @@
+//
+//  EisenhowerConsoleView_tests.swift
+//  t_tests
+//
+
+import XCTest
+import EventKit
+@testable import t
+
+final class EisenhowerConsoleView_tests: XCTestCase {
+
+    private func reminder(priority: Int, title: String = "", isCompleted: Bool = false) -> EKReminder {
+        let reminder = EKReminder(eventStore: EKEventStore())
+        reminder.priority = priority
+        reminder.title = title
+        reminder.isCompleted = isCompleted
+        return reminder
+    }
+
+    private func view(reminders: ReminderDict = [:]) -> EisenhowerConsoleView {
+        let cache = ReminderCache(eventStore: EKEventStore(), reminders: reminders)
+        return EisenhowerConsoleView(reminders: cache)
+    }
+
+    // MARK: - init: leftMaxWidth / rightMaxWidth
+
+    func testInit_emptyCache_maxWidthsFallBackToThirteen() throws {
+        let v = view()
+
+        XCTAssertEqual(v.leftMaxWidth, 13)
+        XCTAssertEqual(v.rightMaxWidth, 13)
+    }
+
+    func testInit_leftMaxWidth_usesLongestTitleAcrossBothLeftQuadrants() throws {
+        let v = view(reminders: [
+            "aaa": reminder(priority: 1, title: "short"),                    // urgentImportant (left)
+            "bbb": reminder(priority: 7, title: "a much longer left title"), // urgentNotImportant (left)
+            "ccc": reminder(priority: 4, title: "an even longer right-side title that should not count"), // right
+        ])
+
+        XCTAssertEqual(v.leftMaxWidth, "a much longer left title".count + 13)
+    }
+
+    func testInit_rightMaxWidth_usesLongestTitleAcrossBothRightQuadrants() throws {
+        let v = view(reminders: [
+            "aaa": reminder(priority: 4, title: "short"),                     // notUrgentImportant (right)
+            "bbb": reminder(priority: 0, title: "a somewhat longer title"),   // notUrgentNotImportant (right)
+            "ccc": reminder(priority: 1, title: "an even longer left-side title that should not count"), // left
+        ])
+
+        XCTAssertEqual(v.rightMaxWidth, "a somewhat longer title".count + 13)
+    }
+
+    // MARK: - format(rem:width:)
+
+    func testFormat_incompleteReminder_hasNoCheckmark() throws {
+        let v = view()
+        let rem = reminder(priority: 2, title: "buy milk", isCompleted: false)
+
+        let result = v.format(rem: rem, width: 40)
+
+        XCTAssertTrue(result.contains(rem.key))
+        XCTAssertTrue(result.contains(" 2 "))
+        XCTAssertTrue(result.contains("buy milk"))
+        XCTAssertFalse(result.contains("\u{2714}"))   // ✔
+    }
+
+    func testFormat_completedReminder_hasCheckmark() throws {
+        let v = view()
+        let rem = reminder(priority: 5, title: "done thing", isCompleted: true)
+
+        let result = v.format(rem: rem, width: 40)
+
+        XCTAssertTrue(result.contains("\u{2714}"))    // ✔
+        XCTAssertTrue(result.contains(rem.key))
+    }
+
+    func testFormat_titleLongerThanWidth_isTruncatedToWidthMinusSix() throws {
+        let v = view()
+        let rem = reminder(priority: 0, title: String(repeating: "x", count: 100))
+
+        let result = v.format(rem: rem, width: 20)
+
+        XCTAssertTrue(result.contains(String(repeating: "x", count: 14)))
+        XCTAssertFalse(result.contains(String(repeating: "x", count: 15)))
+    }
+
+    // MARK: - sortByCompletionAndPriority
+
+    func testSort_bothIncomplete_ordersByPriorityAscending() throws {
+        let v = view()
+        let high = reminder(priority: 1)   // "high" importance within its quadrant
+        let low  = reminder(priority: 3)   // "low" importance within its quadrant
+
+        XCTAssertTrue(v.sortByCompletionAndPriority(r1: high, r2: low))
+        XCTAssertFalse(v.sortByCompletionAndPriority(r1: low, r2: high))
+    }
+
+    func testSort_bothCompleted_ordersByPriorityAscending() throws {
+        let v = view()
+        let high = reminder(priority: 1, isCompleted: true)
+        let low  = reminder(priority: 3, isCompleted: true)
+
+        XCTAssertTrue(v.sortByCompletionAndPriority(r1: high, r2: low))
+        XCTAssertFalse(v.sortByCompletionAndPriority(r1: low, r2: high))
+    }
+
+    func testSort_incompleteAlwaysBeforeCompleted_regardlessOfPriority() throws {
+        let v = view()
+        let incomplete = reminder(priority: 9, isCompleted: false)
+        let completed  = reminder(priority: 1, isCompleted: true)
+
+        XCTAssertTrue(v.sortByCompletionAndPriority(r1: incomplete, r2: completed))
+        XCTAssertFalse(v.sortByCompletionAndPriority(r1: completed, r2: incomplete))
+    }
+}

--- a/Tests/t_tests/main_tests.swift
+++ b/Tests/t_tests/main_tests.swift
@@ -15,6 +15,34 @@ final class main_tests: XCTestCase {
         return reminder
     }
 
+    // MARK: - usage()
+
+    func testUsage_containsHeaderAndExamples() throws {
+        let text = usage()
+
+        XCTAssertTrue(text.contains("usage: t [<command> <options>]"))
+        XCTAssertTrue(text.contains("t c 9d2"))
+        XCTAssertTrue(text.contains("t d 9d2"))
+        XCTAssertTrue(text.contains("t m uni a28"))
+    }
+
+    func testUsage_listsEveryPriorityNameAndDigit() throws {
+        let text = usage()
+
+        for priority in Priority.allCases {
+            XCTAssertTrue(text.contains("\(priority)"), "usage() should mention priority name \"\(priority)\"")
+            XCTAssertTrue(text.contains("priority \(priority.rawValue):"), "usage() should mention priority digit \(priority.rawValue)")
+        }
+    }
+
+    func testUsage_everyLineIsACommentOrBlank() throws {
+        let text = usage()
+
+        for line in text.split(separator: "\n", omittingEmptySubsequences: false) {
+            XCTAssertTrue(line.hasPrefix("#"), "expected every usage() line to start with \"#\", got: \(line)")
+        }
+    }
+
     // MARK: - no command
 
     func testRun_emptyArgs_returnsRender() throws {


### PR DESCRIPTION
## Summary
Both files sat at ~0% line coverage per `swift test --enable-code-coverage` + `llvm-cov report`. #12 already extracted and tested `main.swift`'s command dispatch (`runCommand()`), which left `usage()` as the only remaining testable surface there.

- Changed `usage()` to build and return a `String` instead of calling `print()` directly, so it's testable without stdout-redirection machinery. The call site now does `print(usage())`. This was a purely mechanical transform of each `print("...")` argument into a joined array of the same literals — verified **byte-for-byte identical** `t --help` output before/after (`diff` clean, matching md5 checksums).
- Added `Tests/t_tests/EisenhowerConsoleView_tests.swift` covering `sortByCompletionAndPriority` and `format(rem:width:)` — the two functions the issue named "at minimum" — plus `leftMaxWidth`/`rightMaxWidth`'s per-quadrant title-length computation from `init`.
- Added `usage()` coverage to `Tests/t_tests/main_tests.swift`.
- Left `list_reminders_side_by_side`/`display()` untested — they're I/O-heavy compositing functions built entirely from the now-tested `format`/`sortByCompletionAndPriority`, and the top-level `do`/`catch` block, which is the program's actual entry point and isn't independently callable/testable (same limitation #12 already accepted for the thin dispatcher shell).

**Coverage:** `EisenhowerConsoleView.swift` 0% → 55%, `main.swift` 27.69% → 68.94% (remaining gap there is entirely the untestable top-level entry point).

Fixes #17

## Test plan
- [x] `swift build` succeeds
- [x] `make build` succeeds (entitled binary)
- [x] `swift test` — all 48 tests pass (12 new: 9 in `EisenhowerConsoleView_tests.swift`, 3 `usage()` tests in `main_tests.swift`)
- [x] `swift test --enable-code-coverage` + `xcrun llvm-cov report` confirms the coverage improvement above
- [x] Manually diffed `t --help` output before/after the `usage()` refactor — identical (md5 `b1de66052186591962e14f74960198d5` both before and after)